### PR TITLE
log -> logrus

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strings"
 

--- a/consul/data_source_consul_service_health.go
+++ b/consul/data_source_consul_service_health.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/consul/key_client.go
+++ b/consul/key_client.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/consul/resource_consul_keys_migrate.go
+++ b/consul/resource_consul_keys_migrate.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -3,7 +3,7 @@ package consul
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strings"
 


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)